### PR TITLE
change: update sign-aws-request

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -7,11 +7,7 @@
 // form-urlencoded
 
 import { post } from 'httpie'
-
-// bug in import/extensions: https://github.com/benmosher/eslint-plugin-import/issues/1887
-// eslint-disable-next-line import/extensions, import/no-unresolved
-import { createAwsSigner as create_aws_signer } from '#sign-aws-requests'
-
+import { createAwsSigner as create_aws_signer } from 'sign-aws-requests'
 import parse_xml from '@rgrove/parse-xml'
 
 import { convert_to_attributes_object, generic_attributes_builder } from './convert_to_attributes_object.mjs'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@rgrove/parse-xml": "^2.0.4",
         "httpie": "^2.0.0-next.9",
         "just-pascal-case": "^1.1.0",
-        "sign-aws-requests": "^1.0.1"
+        "sign-aws-requests": "^2.0.0"
       },
       "devDependencies": {
         "uvu": "^0.5.1"
@@ -88,11 +88,11 @@
       }
     },
     "node_modules/sign-aws-requests": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sign-aws-requests/-/sign-aws-requests-1.0.1.tgz",
-      "integrity": "sha512-ncnhlIKzry2rnSA5J5dUfQ8zdVHzMm+u161jxnJNTtbCeEU3gMN15maF3rNEguvaeZTz2ZdWpyThfHdjoAQiAg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sign-aws-requests/-/sign-aws-requests-2.0.0.tgz",
+      "integrity": "sha512-h3uj/8iE1FTFsof5Z/aBgSAf5qDc06CIIjc4mYuU3B0c64Zfb4gFEKpS7RNZww/plgpBnvcgzf9lRhz2Xbn5/g==",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 16"
       }
     },
     "node_modules/totalist": {
@@ -174,9 +174,9 @@
       }
     },
     "sign-aws-requests": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sign-aws-requests/-/sign-aws-requests-1.0.1.tgz",
-      "integrity": "sha512-ncnhlIKzry2rnSA5J5dUfQ8zdVHzMm+u161jxnJNTtbCeEU3gMN15maF3rNEguvaeZTz2ZdWpyThfHdjoAQiAg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sign-aws-requests/-/sign-aws-requests-2.0.0.tgz",
+      "integrity": "sha512-h3uj/8iE1FTFsof5Z/aBgSAf5qDc06CIIjc4mYuU3B0c64Zfb4gFEKpS7RNZww/plgpBnvcgzf9lRhz2Xbn5/g=="
     },
     "totalist": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,14 +23,11 @@
     "url": "https://github.com/trex-arms/sqs/issues"
   },
   "homepage": "https://github.com/trex-arms/sqs#readme",
-  "imports": {
-    "#sign-aws-requests": "sign-aws-requests/dist/sign-aws-requests.mjs"
-  },
   "dependencies": {
     "@rgrove/parse-xml": "^2.0.4",
     "httpie": "^2.0.0-next.9",
     "just-pascal-case": "^1.1.0",
-    "sign-aws-requests": "^1.0.1"
+    "sign-aws-requests": "^2.0.0"
   },
   "devDependencies": {
     "uvu": "^0.5.1"


### PR DESCRIPTION
The recent update to `sign-aws-request` added `exports` fields to the `package.json`, so you shouldn't need these shenanigans anymore.