### PR TITLE
RFC: Do No JSON

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,3 @@
+# 2.0.0
+- No longer attempt to `JSON.stringify` or `JSON.parse` SQS message bodies
+- Add a type definitions file

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
 # 2.0.0
 - No longer attempt to `JSON.stringify` or `JSON.parse` SQS message bodies
 - Add a type definitions file
+- Use built-in `fetch` instead of [`httpie`](https://github.com/lukeed/httpie)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,37 @@
+declare module '@trex-arms/sqs' {
+	type Attributes = { [key: string]: any }
+
+	type MessageResponse = { message_id: string, md5_of_body: string }
+
+	export type Sqs = {
+		create_queue: (name: string, attributes?: Attributes) => Promise<string>
+		get_queue_url: (name: string) => Promise<string>
+		get_queue_attributes: (queue_url: string, attribute_names: string[]) => Promise<Attributes>
+		delete_queue: (queue_url: string) => Promise<void>
+		send_message: (queue_url: string, message: string, opts?: { delay_seconds?: number, message_attribute?: Attributes }) => Promise<MessageResponse>
+		send_message_batch: (queue_url: string, messages: string[]) => Promise<MessageResponse[]>
+		receive_message: (queue_url: string, opts?: {
+			max_number_of_messages?: number
+			visibility_timeout?: number
+			wait_time_seconds?: number
+			attribute_names?: string[]
+		}) => Promise<{
+			body: string
+			message_id: string
+			md5_of_body: string
+			receipt_handle: string
+			attributes: Attributes
+		}>
+		delete_message: (queue_url: string, receipt_handle: string) => Promise<void>
+	}
+
+	type CreateSqs = (args: {
+		access_key_id: string
+		secret_access_key: string
+		region: string
+	}) => Sqs
+
+	const sqs: CreateSqs
+
+	export default sqs
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,37 +1,35 @@
-declare module '@trex-arms/sqs' {
-	type Attributes = { [key: string]: any }
+type Attributes = { [key: string]: any }
 
-	type MessageResponse = { message_id: string, md5_of_body: string }
+type MessageResponse = { message_id: string, md5_of_body: string }
 
-	export type Sqs = {
-		create_queue: (name: string, attributes?: Attributes) => Promise<string>
-		get_queue_url: (name: string) => Promise<string>
-		get_queue_attributes: (queue_url: string, attribute_names: string[]) => Promise<Attributes>
-		delete_queue: (queue_url: string) => Promise<void>
-		send_message: (queue_url: string, message: string, opts?: { delay_seconds?: number, message_attribute?: Attributes }) => Promise<MessageResponse>
-		send_message_batch: (queue_url: string, messages: string[]) => Promise<MessageResponse[]>
-		receive_message: (queue_url: string, opts?: {
-			max_number_of_messages?: number
-			visibility_timeout?: number
-			wait_time_seconds?: number
-			attribute_names?: string[]
-		}) => Promise<{
-			body: string
-			message_id: string
-			md5_of_body: string
-			receipt_handle: string
-			attributes: Attributes
-		}[]>
-		delete_message: (queue_url: string, receipt_handle: string) => Promise<void>
-	}
-
-	type CreateSqs = (args: {
-		access_key_id: string
-		secret_access_key: string
-		region: string
-	}) => Sqs
-
-	const sqs: CreateSqs
-
-	export default sqs
+export type Sqs = {
+	create_queue: (name: string, attributes?: Attributes) => Promise<string>
+	get_queue_url: (name: string) => Promise<string>
+	get_queue_attributes: (queue_url: string, attribute_names: string[]) => Promise<Attributes>
+	delete_queue: (queue_url: string) => Promise<void>
+	send_message: (queue_url: string, message: string, opts?: { delay_seconds?: number, message_attribute?: Attributes }) => Promise<MessageResponse>
+	send_message_batch: (queue_url: string, messages: string[]) => Promise<MessageResponse[]>
+	receive_message: (queue_url: string, opts?: {
+		max_number_of_messages?: number
+		visibility_timeout?: number
+		wait_time_seconds?: number
+		attribute_names?: string[]
+	}) => Promise<{
+		body: string
+		message_id: string
+		md5_of_body: string
+		receipt_handle: string
+		attributes: Attributes
+	}[]>
+	delete_message: (queue_url: string, receipt_handle: string) => Promise<void>
 }
+
+type CreateSqs = (args: {
+	access_key_id: string
+	secret_access_key: string
+	region: string
+}) => Sqs
+
+const sqs: CreateSqs
+
+export default sqs

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module '@trex-arms/sqs' {
 			md5_of_body: string
 			receipt_handle: string
 			attributes: Attributes
-		}>
+		}[]>
 		delete_message: (queue_url: string, receipt_handle: string) => Promise<void>
 	}
 

--- a/index.mjs
+++ b/index.mjs
@@ -182,7 +182,7 @@ export default ({ access_key_id, secret_access_key, region }) => {
 		}),
 		send_message: (queue_url, message, { delay_seconds, message_attribute = {} } = {}) => request(queue_url, {
 			Action: `SendMessage`,
-			MessageBody: JSON.stringify(message),
+			MessageBody: message,
 			DelaySeconds: delay_seconds,
 			...convert_to_attributes_object(message_attribute, { name: `MessageAttribute`, type: true }),
 		}).then(
@@ -206,7 +206,7 @@ export default ({ access_key_id, secret_access_key, region }) => {
 			...generic_attributes_builder(
 				messages.map((message, i) => ({
 					Id: `message_${ i }`,
-					MessageBody: JSON.stringify(message),
+					MessageBody: message,
 				})),
 				{
 					name: `SendMessageBatchRequestEntry`,
@@ -237,7 +237,7 @@ export default ({ access_key_id, secret_access_key, region }) => {
 					`Message`,
 				).map(
 					message => ({
-						body: JSON.parse(read_text_from_descendant(message, `Body`)),
+						body: read_text_from_descendant(message, `Body`),
 						message_id: read_text_from_descendant(message, `MessageId`),
 						md5_of_body: read_text_from_descendant(message, `MD5OfBody`),
 						receipt_handle: read_text_from_descendant(message, `ReceiptHandle`),

--- a/index.test.mjs
+++ b/index.test.mjs
@@ -81,7 +81,7 @@ test(`send, receive`, async() => {
 
 	const queue_url = await sqs.create_queue(`test_automated_read_write`)
 
-	const message_body = { test: `yes`, number: 2 }
+	const message_body = "{ test: `yes`, number: 2 }"
 
 	const result_of_send = await sqs.send_message(queue_url, message_body)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trex-arms/sqs",
-  "version": "1.3.1-0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@trex-arms/sqs",
-      "version": "1.3.1-0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@rgrove/parse-xml": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "",
   "main": "index.mjs",
+  "types": "index.d.ts",
   "type": "module",
   "scripts": {
     "test": "uvu"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trex-arms/sqs",
-  "version": "1.3.1-0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.mjs",
   "type": "module",

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ Functions on the `sqs` object:
 - `send_message_batch(queue_url, messages)`
 	- returns an array of `{ message_id, md5_of_body }`
 - `receive_message(queue_url, { max_number_of_messages, visibility_timeout, wait_time_seconds, attribute_names = [] } = {})`
-	- returns `{ body, message_id, md5_of_body, receipt_handle, attributes }`
+	- returns `{ body, message_id, md5_of_body, receipt_handle, attributes }[]`
 - `delete_message(queue_url, receipt_handle)`
 
 Attribute objects are expected to have `snake_case` properties.

--- a/readme.md
+++ b/readme.md
@@ -34,12 +34,10 @@ Functions on the `sqs` object:
 	- returns attributes (object)
 - `delete_queue(queue_url)`
 - `send_message(queue_url, message, { delay_seconds, message_attribute = {} } = {})`
-	- message is converted to JSON via `JSON.stringify(message)`
 	- returns `{ message_id, md5_of_body }`
 - `send_message_batch(queue_url, messages)`
 	- returns an array of `{ message_id, md5_of_body }`
 - `receive_message(queue_url, { max_number_of_messages, visibility_timeout, wait_time_seconds, attribute_names = [] } = {})`
-	- message bodies are parsed via `JSON.parse(message)`
 	- returns `{ body, message_id, md5_of_body, receipt_handle, attributes }`
 - `delete_message(queue_url, receipt_handle)`
 


### PR DESCRIPTION
While T.REX predominantly encodes its SQS messages using JSON, this package is not the sole source of messages on our queues, and there is no guarantee that messages will be valid JSON.

We want to be able to have finer-grained error handling around non-JSON messages, which this package currently doesn't allow since it takes it upon itself to encode and decode JSON.  I believe that should be the responsibility of the consumer, not the package.  